### PR TITLE
Improve the user experience of the beCalled and mostRecentlyBeCalled matchers.

### DIFF
--- a/Sources/Fakes/Spy+Nimble.swift
+++ b/Sources/Fakes/Spy+Nimble.swift
@@ -1,49 +1,56 @@
 import Nimble
 
-/// A Nimble matcher for ``Spy`` that succeeds when the spy has been called at least once.
-public func beCalled<Arguments, Returning>() -> Matcher<Spy<Arguments, Returning>> {
-    return Matcher.define("be called") { expression, message in
-        guard let spy = try expression.evaluate() else {
-            return MatcherResult(status: .fail, message: message.appendedBeNilHint())
-        }
-        return MatcherResult(bool: spy.calls.isEmpty == false, message: message)
-    }
-}
+// MARK: - Verifying any calls to the Spy.
 
-/// A Nimble matcher for ``Spy`` that succeeds when the spy has been called the exact amount of times specified.
+/// A Nimble matcher for ``Spy`` that succeeds when any of the calls to the spy matches the given matchers.
 ///
-/// - parameter times: the amount of times you expect the Spy to have been called.
-public func beCalled<Arguments, Returning>(times: Int) -> Matcher<Spy<Arguments, Returning>> {
-    return Matcher.define("be called") { expression, message in
-        guard let spy = try expression.evaluate() else {
-            return MatcherResult(status: .fail, message: message.appendedBeNilHint())
-        }
-        return MatcherResult(bool: spy.calls.count == times, message: message)
-    }
-}
-
-/// A Nimble matcher for ``Spy`` that succeeds when any of the calls to the spy matches the given matcher.
+/// If no matchers are specified, then this matcher will succeed if the spy has been called at all.
 ///
-/// - parameter matcher: The matcher to run against the calls to spy to verify it has been called correctly
-/// - Note: If the Spy's `Arguments` is Equatable, you can use `BeCalled` with the expected value. This is the same as `beCalled(equal(expectedValue))`.
-/// - SeeAlso: ``mostRecentlyBeCalled(_:)`` for when you want to check that only the most recent call to the spy matches the matcher.
-public func beCalled<Arguments, Returning>(_ matcher: Matcher<Arguments>) -> Matcher<Spy<Arguments, Returning>> {
-    return Matcher.define("be called with \(stringify(matcher))") { expression, message in
-        guard let spy = try expression.evaluate() else {
-            return MatcherResult(status: .fail, message: message.appendedBeNilHint())
+/// - parameter matchers: The matchers to run against the calls to spy to verify it has been called correctly
+/// - Note: If the Spy's `Arguments` is Equatable, you can use `BeCalled` with
+/// the expected value. This is the same as `beCalled(equal(expectedValue))`.
+/// - Note: All matchers for a single call must pass in order for this matcher
+/// to pass. Specifying multiple matchers DOES NOT verify multiple calls.
+/// Passing in multiple matchers is a shorthand for `beCalled(satisfyAllOf(...))`.
+/// - SeeAlso: ``mostRecentlyBeCalled(_:)`` for when you want to check that
+/// only the most recent call to the spy matches the matcher.
+public func beCalled<Arguments, Returning>(
+    _ matchers: Matcher<Arguments>...
+) -> Matcher<Spy<Arguments, Returning>> {
+    let rawMessage: String
+    if matchers.isEmpty {
+        rawMessage = "be called"
+    } else {
+        rawMessage = "be called with \(matchers.count) matchers"
+    }
+    return _beCalled(rawMessage: rawMessage) { validatorArgs in
+        if matchers.isEmpty {
+            return MatcherResult(
+                bool: validatorArgs.spy.calls.isEmpty == false,
+                message: validatorArgs.message)
         }
-
-        for call in spy.calls {
+        for call in validatorArgs.spy.calls {
             let matcherExpression = Expression(
                 expression: { call },
-                location: expression.location
+                location: validatorArgs.expression.location
             )
-            let result = try matcher.satisfies(matcherExpression)
-            if result.toBoolean(expectation: .toMatch) {
-                return MatcherResult(bool: true, message: message)
+            let results = try matchers.map {
+                try $0.satisfies(matcherExpression)
+            }
+            if results.allSatisfy({ $0.toBoolean(expectation: .toMatch) }) {
+                return MatcherResult(
+                    bool: true,
+                    message: validatorArgs.message.appended(
+                        details: results.map {
+                            $0.message.toString(
+                                actual: stringify(validatorArgs.spy)
+                            )
+                        }.joined(separator: "\n")
+                    )
+                )
             }
         }
-        return MatcherResult(bool: false, message: message)
+        return MatcherResult(bool: false, message: validatorArgs.message)
     }
 }
 
@@ -51,38 +58,70 @@ public func beCalled<Arguments, Returning>(_ matcher: Matcher<Arguments>) -> Mat
 /// `times` times, and it has been called at least once with arguments that match
 /// the matcher.
 ///
-/// For example, if your spy has been called a total of 4 times, and at least of those times matching whatever
-/// your matcher is, then `beCalled(..., times: 4)` will match.
+/// If no matchers are given, then this matcher will succeed if the spy has
+/// been called exactly the number of times specified.
+///
+/// For example, if your spy has been called a total of 4 times, and at least one of those times matching
+/// whatever your matcher is, then `beCalled(..., times: 4)` will match.
 /// However, `beCalled(..., times: 3)` will not match, because the matcher has been called 4 times.
 /// If you wish to check how much the spy has been called in total, use ``beCalled(times:)``.
 ///
-/// This is a shorthand for `satisfyAllOf(beCalled(times: times), beCalled(matcher))`
+/// Alternatively, if your spy has been called a total of 4 times, and you pass in 0 matchers, then
+/// `beCalled(times: 4)` will match, regardless of what those calls are.
 ///
-/// - parameter matcher: The matcher used to search for matching calls.
+/// - parameter matchers: The matchers used to search for matching calls.
 /// - parameter times: The expected amount of calls the Spy should have been called.
-public func beCalled<Arguments, Returning>(_ matcher: Matcher<Arguments>, times: Int) -> Matcher<Spy<Arguments, Returning>> {
-    return Matcher.define("be called with \(stringify(matcher)) \(times) times") { expression, message in
-        guard let spy = try expression.evaluate() else {
-            return MatcherResult(status: .fail, message: message.appendedBeNilHint())
-        }
-
-        let calls = spy.calls
+///
+/// - Note: All matchers for a single call must pass in order for this matcher
+/// to pass. Specifying multiple matchers DOES NOT verify multiple calls.
+/// Passing in multiple matchers is a shorthand for `beCalled(satisfyAllOf(...))`.
+public func beCalled<Arguments, Returning>(
+    _ matchers: Matcher<Arguments>...,
+    times: Int
+) -> Matcher<Spy<Arguments, Returning>> {
+    let rawMessage: String
+    if matchers.isEmpty {
+        rawMessage = "be called \(times) times"
+    } else {
+        rawMessage = "be called \(times) times, at least one of them matches \(matchers.count) matchers"
+    }
+    return _beCalled(rawMessage: rawMessage) { validatorArgs in
+        let calls = validatorArgs.spy.calls
 
         if calls.count != times {
-            return MatcherResult(bool: false, message: message.appended(details: "but was called \(calls.count) times"))
+            return MatcherResult(
+                bool: false,
+                message: validatorArgs.message.appended(
+                    details: "but was called \(calls.count) times"
+                )
+            )
         }
 
+        if matchers.isEmpty {
+            return MatcherResult(bool: true, message: validatorArgs.message)
+        }
         for call in calls {
             let matcherExpression = Expression(
                 expression: { call },
-                location: expression.location
+                location: validatorArgs.expression.location
             )
-            let result = try matcher.satisfies(matcherExpression)
-            if result.toBoolean(expectation: .toMatch) {
-                return MatcherResult(bool: true, message: message)
+            let results = try matchers.map {
+                try $0.satisfies(matcherExpression)
+            }
+            if results.allSatisfy({ $0.toBoolean(expectation: .toMatch) }) {
+                return MatcherResult(
+                    bool: true,
+                    message: validatorArgs.message.appended(
+                        details: results.map {
+                            $0.message.toString(
+                                actual: stringify(validatorArgs.spy)
+                            )
+                        }.joined(separator: "\n")
+                    )
+                )
             }
         }
-        return MatcherResult(bool: false, message: message)
+        return MatcherResult(bool: false, message: validatorArgs.message)
     }
 }
 
@@ -90,8 +129,16 @@ public func beCalled<Arguments, Returning>(_ matcher: Matcher<Arguments>, times:
 ///
 /// - parameter value: The expected value of any of the calls to the `Spy`.
 /// - SeeAlso: ``beCalled(_:)``
-public func beCalled<Arguments, Returning>(_ value: Arguments) -> Matcher<Spy<Arguments, Returning>> where Arguments: Equatable {
-    beCalled(equal(value))
+public func beCalled<Arguments, Returning>(
+    _ value: Arguments
+) -> Matcher<Spy<Arguments, Returning>> where Arguments: Equatable {
+    let rawMessage = "be called with \(stringify(value))"
+    return _beCalled(rawMessage: rawMessage) { validatorArgs in
+        return MatcherResult(
+            bool: validatorArgs.spy.calls.contains(value),
+            message: validatorArgs.message
+        )
+    }
 }
 
 /// A Nimble matcher for ``Spy`` that succeeds when the spy has been called `times` times,
@@ -103,30 +150,58 @@ public func beCalled<Arguments, Returning>(_ value: Arguments) -> Matcher<Spy<Ar
 /// - parameter times: The expected amount of calls the Spy should have been called.
 /// - SeeAlso: ``beCalled(_:)``
 public func beCalled<Arguments, Returning>(_ value: Arguments, times: Int) -> Matcher<Spy<Arguments, Returning>> where Arguments: Equatable {
-    beCalled(equal(value), times: times)
+    let rawMessage = "be called \(times) times, at least one of them is \(stringify(value))"
+    return _beCalled(rawMessage: rawMessage) { validatorArgs in
+        let calls = validatorArgs.spy.calls
+        if calls.count != times {
+            return MatcherResult(
+                bool: false,
+                message: validatorArgs.message.appended(
+                    details: "but was called \(calls.count) times"
+                )
+            )
+        }
+        return MatcherResult(
+            bool: calls.contains(value),
+            message: validatorArgs.message
+        )
+    }
 }
 
-/// A Nimble matcher for ``Spy`` that succeeds when the most recent call to the spy matches the given matcher.
+// MARK: - Verifying the last call to the Spy
+
+/// A Nimble matcher for ``Spy`` that succeeds when the most recent call to the spy matches the given matchers.
 ///
+/// - Note: This matcher will fail if no matchers have been passed.
 /// - SeeAlso: ``beCalled(_:)`` for when you want to check if any of the calls to the spy match the matcher.
 /// - SeeAlso: ``mostRecentlyBeCalled(_:)`` as a shorthand when Arguments is equatable, and you want to check if it's equal to some value.
-public func mostRecentlyBeCalled<Arguments, Returning>(_ matcher: Matcher<Arguments>) -> Matcher<Spy<Arguments, Returning>> {
-    return Matcher.define("most recently be called with \(stringify(matcher))") { expression, message in
-        guard let spy = try expression.evaluate() else {
-            return MatcherResult(status: .fail, message: message.appendedBeNilHint())
-        }
-
-        guard let lastCall = spy.calls.last else {
-            return MatcherResult(status: .fail, message: message.appended(message: "but spy was never called."))
+public func mostRecentlyBeCalled<Arguments, Returning>(_ matchers: Matcher<Arguments>...) -> Matcher<Spy<Arguments, Returning>> {
+    let rawMessage = "most recently be called with \(matchers.count) matchers"
+    return _mostRecentlyBeCalled(rawMessage: rawMessage) { validatorArgs in
+        guard matchers.isEmpty == false else {
+            return MatcherResult(status: .fail, message: validatorArgs.message.appended(
+                message: "Error: No matchers were specified. " +
+                "Use `beCalled()` to check if the spy has been called at all."
+            ))
         }
 
         let matcherExpression = Expression(
-            expression: { lastCall },
-            location: expression.location
+            expression: { validatorArgs.lastCall },
+            location: validatorArgs.expression.location
         )
-        let result = try matcher.satisfies(matcherExpression)
-
-        return MatcherResult(bool: result.toBoolean(expectation: .toMatch), message: message)
+        let results = try matchers.map {
+            try $0.satisfies(matcherExpression)
+        }
+        if results.allSatisfy({ $0.toBoolean(expectation: .toMatch) }) {
+        }
+        return MatcherResult(
+            bool: results.allSatisfy { $0.toBoolean(expectation: .toMatch) },
+            message: validatorArgs.message.appended(details: results.map {
+                $0.message.toString(
+                    actual: stringify(validatorArgs.spy)
+                )
+            }.joined(separator: "\n"))
+        )
     }
 }
 
@@ -134,12 +209,98 @@ public func mostRecentlyBeCalled<Arguments, Returning>(_ matcher: Matcher<Argume
 ///
 /// - SeeAlso: ``beCalled(_:)`` for when you want to check if any of the calls to the spy are equal to the expected value
 /// - SeeAlso: ``mostRecentlyBeCalled(_:)`` when you want to use a Matcher to check if the most recent call matches.
-public func mostRecentlyBeCalled<Arguments, Returning>(_ value: Arguments) -> Matcher<Spy<Arguments, Returning>> where Arguments: Equatable {
-    mostRecentlyBeCalled(equal(value))
+public func mostRecentlyBeCalled<Arguments, Returning>(
+    _ value: Arguments
+) -> Matcher<Spy<Arguments, Returning>> where Arguments: Equatable {
+    let rawMessage = "most recently be called with \(stringify(value))"
+    return _mostRecentlyBeCalled(rawMessage: rawMessage) { validatorArgs in
+        return MatcherResult(
+            bool: validatorArgs.lastCall == value,
+            message: validatorArgs.message.appended(
+                message: "but got \(stringify(validatorArgs.lastCall))"
+            )
+        )
+    }
 }
 
 extension Spy: CustomDebugStringConvertible {
     public var debugDescription: String {
         return "Spy<\(stringify(Arguments.self)), \(stringify(Returning.self))>, calls: \(stringify(calls))"
+    }
+}
+
+// MARK: - Private
+
+private struct BeCalledValidatorArgs<Arguments, Returning> {
+    let spy: Spy<Arguments, Returning>
+    let expression: Expression<Spy<Arguments, Returning>>
+    let message: ExpectationMessage
+
+    init(
+        _ spy: Spy<Arguments, Returning>,
+        _ expression: Expression<Spy<Arguments, Returning>>,
+        _ message: ExpectationMessage
+    ) {
+        self.spy = spy
+        self.expression = expression
+        self.message = message
+    }
+}
+
+private func _beCalled<Arguments, Returning>(
+    rawMessage: String,
+    validator: @escaping (BeCalledValidatorArgs<Arguments, Returning>) throws -> MatcherResult
+) -> Matcher<Spy<Arguments, Returning>> {
+    return Matcher.define(rawMessage) { expression, message in
+        guard let spy = try expression.evaluate() else {
+            return MatcherResult(status: .fail, message: message.appendedBeNilHint())
+        }
+
+        return try validator(BeCalledValidatorArgs(spy, expression, message))
+    }
+}
+
+private struct MostRecentlyBeCalledValidatorArgs<Arguments, Returning> {
+    let lastCall: Arguments
+    let spy: Spy<Arguments, Returning>
+    let expression: Expression<Spy<Arguments, Returning>>
+    let message: ExpectationMessage
+
+    init(
+        _ lastCall: Arguments,
+        _ spy: Spy<Arguments, Returning>,
+        _ expression: Expression<Spy<Arguments, Returning>>,
+        _ message: ExpectationMessage
+    ) {
+        self.lastCall = lastCall
+        self.spy = spy
+        self.expression = expression
+        self.message = message
+    }
+}
+
+private func _mostRecentlyBeCalled<Arguments, Returning>(
+    rawMessage: String,
+    validator: @escaping (
+        MostRecentlyBeCalledValidatorArgs<Arguments, Returning>
+    ) throws -> MatcherResult
+) -> Matcher<Spy<Arguments, Returning>> {
+    return _beCalled(rawMessage: rawMessage) { beCalledValidatorArgs in
+        guard let lastCall = beCalledValidatorArgs.spy.calls.last else {
+            return MatcherResult(
+                status: .fail,
+                message: beCalledValidatorArgs.message.appended(
+                    message: "but spy was never called."
+                )
+            )
+        }
+        return try validator(
+            MostRecentlyBeCalledValidatorArgs(
+                lastCall,
+                beCalledValidatorArgs.spy,
+                beCalledValidatorArgs.expression,
+                beCalledValidatorArgs.message
+            )
+        )
     }
 }

--- a/Tests/FakesTests/SpyTests+Nimble.swift
+++ b/Tests/FakesTests/SpyTests+Nimble.swift
@@ -30,6 +30,20 @@ final class SpyNimbleMatchersTest: XCTestCase {
         expect(spy).to(beCalled(3))
     }
 
+    func testBeCalledWithMultipleArguments() {
+        let spy = Spy<Int, Void>()
+
+        spy(3)
+        expect(spy).toNot(beCalled(
+            equal(2),
+            beLessThan(4)
+        ))
+        expect(spy).to(beCalled(
+            equal(3),
+            beLessThan(4)
+        ))
+    }
+
     func testBeCalledWithTimes() {
         let spy = Spy<Int, Void>()
 
@@ -66,6 +80,19 @@ final class SpyNimbleMatchersTest: XCTestCase {
         expect(spy).to(beCalled(3, times: 2))
     }
 
+    func testBeCalledWithMultipleArgumentsAndTimes() {
+        let spy = Spy<Int, Void>()
+
+        spy(1)
+
+        expect(spy).toNot(beCalled(equal(2), beLessThan(3), times: 1))
+        expect(spy).to(beCalled(equal(1), beLessThan(3), times: 1))
+
+        spy(3)
+        expect(spy).toNot(beCalled(equal(2), beLessThan(4), times: 2))
+        expect(spy).to(beCalled(equal(3), beLessThan(4), times: 2))
+    }
+
     func testMostRecentlyBeCalled() {
         let spy = Spy<Int, Void>()
 
@@ -81,5 +108,29 @@ final class SpyNimbleMatchersTest: XCTestCase {
 
         expect(spy).toNot(mostRecentlyBeCalled(1))
         expect(spy).to(mostRecentlyBeCalled(2))
+    }
+
+    func testMostRecentlyBeCalledWithMultipleArguments() {
+        let spy = Spy<Int, Void>()
+
+        spy(1)
+        expect(spy).to(mostRecentlyBeCalled(
+            equal(1),
+            beLessThan(3)
+        ))
+        expect(spy).toNot(mostRecentlyBeCalled(
+            equal(2),
+            beLessThan(3)
+        ))
+
+        spy(2)
+        expect(spy).toNot(mostRecentlyBeCalled(
+            equal(1),
+            beLessThan(3)
+        ))
+        expect(spy).to(mostRecentlyBeCalled(
+            equal(2),
+            beLessThan(3)
+        ))
     }
 }


### PR DESCRIPTION
- Allows beCalled and mostRecentlyBeCalled to take in any number of matchers, acting as a shorthand for satisfyAllOf.
- Simplifies the overloads for beCalled.
- Extracts out common private functions for handling the matchers of beCalled and mostRecentlyBeCalled
- Improves the messaging for beCalled/mostRecentlyBeCalled when using an Equatable value
- For mostRecentlyBeCalled, you will now get information about the matcher details when the matcher does not match because one or more of the submatchers didn't match.
- For beCalled you will get information about matcher details in the negated case (when all submatchers match, and you used `toNot`).

This does add a new feature, so would be a minor release per semver.