### PR TITLE
Move setting the Pendable fallback up from being an argument to resolve, to being an associated type of the pending case

### DIFF
--- a/Sources/Fakes/Spy+Result.swift
+++ b/Sources/Fakes/Spy+Result.swift
@@ -1,0 +1,53 @@
+public typealias ThrowingSpy<Arguments, Success, Failure: Error> = Spy<Arguments, Result<Success, Failure>>
+
+extension Spy {
+    /// Create a throwing Spy that is pre-stubbed with some Success value.
+    public convenience init<Success, Failure: Error>(success: Success) where Returning == Result<Success, Failure> {
+        self.init(.success(success))
+    }
+
+    /// Create a throwing Spy that is pre-stubbed with a Void Success value
+    public convenience init<Failure: Error>() where Returning == Result<Void, Failure> {
+        self.init(.success(()))
+    }
+
+    /// Create a throwing Spy that is pre-stubbed with some Failure error.
+    public convenience init<Success, Failure: Error>(failure: Failure) where Returning == Result<Success, Failure> {
+        self.init(.failure(failure))
+    }
+}
+
+extension Spy {
+    /// Update the throwing Spy's stub to be successful, with the given value.
+    ///
+    /// - parameter success: The success state to set the stub to, returned when `callAsFunction` is called.
+    public func stub<Success, Failure: Error>(success: Success) where Returning == Result<Success, Failure> {
+        self.stub(.success(success))
+    }
+
+    /// Update the throwing Spy's stub to be successful, with the given value.
+    ///
+    /// - parameter success: The success state to set the stub to, returned when `callAsFunction` is called.
+    public func stub<Failure: Error>() where Returning == Result<Void, Failure> {
+        self.stub(.success(()))
+    }
+
+    /// Update the throwing Spy's stub to throw the given error.
+    ///
+    /// - parameter failure: The error to throw when `callAsFunction` is called.
+    public func stub<Success, Failure: Error>(failure: Failure) where Returning == Result<Success, Failure> {
+        self.stub(.failure(failure))
+    }
+}
+
+extension Spy {
+    /// Records the arguments and returns the success (or throws an error), as defined by the current stub.
+    public func callAsFunction<Success, Failure: Error>(_ arguments: Arguments) throws -> Success where Returning == Result<Success, Failure> {
+        return try call(arguments).get()
+    }
+
+    /// Records that a call was made and returns the success (or throws an error), as defined by the current stub.
+    public func callAsFunction<Success, Failure: Error>() throws -> Success where Arguments == Void, Returning == Result<Success, Failure> {
+        return try call(()).get()
+    }
+}

--- a/Sources/Fakes/Spy+StaticPendable.swift
+++ b/Sources/Fakes/Spy+StaticPendable.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+public typealias PendableSpy<Arguments, Value> = Spy<Arguments, Pendable<Value>>
+
+extension Spy {
+    /// Create a pendable Spy that is pre-stubbed to return return a a pending that will block for a bit before returning the fallback value.
+    public convenience init<Value>(pendingFallback: Value) where Returning == Pendable<Value> {
+        self.init(.pending(fallback: pendingFallback))
+    }
+
+    /// Create a pendable Spy that is pre-stubbed to return return a a pending that will block for a bit before returning Void.
+    public convenience init() where Returning == Pendable<Void> {
+        self.init(.pending(fallback: ()))
+    }
+
+    /// Create a pendable Spy that is pre-stubbed to return a finished value.
+    public convenience init<Value>(finished: Value) where Returning == Pendable<Value> {
+        self.init(.finished(finished))
+    }
+}
+
+extension Spy {
+    /// Update the pendable Spy's stub to be in a pending state.
+    public func stub<Value>(pendingFallback: Value) where Returning == Pendable<Value> {
+        self.stub(.pending(fallback: pendingFallback))
+    }
+
+    /// Update the pendable Spy's stub to be in a pending state.
+    public func stubPending() where Returning == Pendable<Void> {
+        self.stub(.pending(fallback: ()))
+    }
+
+    /// Update the pendable Spy's stub to return the given value.
+    ///
+    /// - parameter finished: The value to return  when `callAsFunction` is called.
+    public func stub<Value>(finished: Value) where Returning == Pendable<Value> {
+        self.stub(.finished(finished))
+    }
+
+    /// Update the pendable Spy's stub to be in a pending state.
+    public func stubFinished() where Returning == Pendable<Void> {
+        self.stub(.finished(()))
+    }
+}
+
+extension Spy {
+    /// Records the arguments and handles the result according to ``Pendable.call(delay:)``.
+    ///
+    /// - parameter arguments: The arguments to record.
+    /// - parameter pendingDelay: The amount of seconds to delay if the `Pendable` is .pending before
+    /// returning the `pendingFallback`. If the `Pendable` is .finished, then this value is ignored.
+    ///
+    /// Because of how ``Pendable`` currently works, you must provide a fallback option for when the Pendable is pending.
+    /// Alternatively, you can use the throwing version of `callAsFunction`, which will thorw an error instead of returning the fallback.
+    public func callAsFunction<Value>(
+        _ arguments: Arguments,
+        pendingDelay: TimeInterval = PendableDefaults.delay
+    ) async -> Value where Returning == Pendable<Value> {
+        return await call(arguments).resolve(delay: pendingDelay)
+    }
+
+    /// Records that a call was made and handles the result according to ``Pendable.call(delay:)``.
+    ///
+    /// - parameter pendingDelay: The amount of seconds to delay if the `Pendable` is .pending before
+    /// returning the `pendingFallback`. If the `Pendable` is .finished, then this value is ignored.
+    ///
+    /// Because of how ``Pendable`` currently works, you must provide a fallback option for when the Pendable is pending.
+    /// Alternatively, you can use the throwing version of `callAsFunction`, which will thorw an error instead of returning the fallback.
+    public func callAsFunction<Value>(
+        pendingDelay: TimeInterval = PendableDefaults.delay
+    ) async -> Value where Arguments == Void, Returning == Pendable<Value> {
+        return await call(()).resolve(delay: pendingDelay)
+    }
+}

--- a/Sources/Fakes/Spy+StaticThrowingPendable.swift
+++ b/Sources/Fakes/Spy+StaticThrowingPendable.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+public typealias ThrowingPendableSpy<Arguments, Success, Failure: Error> = Spy<Arguments, ThrowingPendable<Success, Failure>>
+
+extension Spy {
+    /// Create a throwing pendable Spy that is pre-stubbed to return a pending that will block for a bit before returning success.
+    public convenience init<Success, Failure: Error>(pendingSuccess: Success) where Returning == ThrowingPendable<Success, Failure> {
+        self.init(.pending(fallback: .success(pendingSuccess)))
+    }
+
+    /// Create a throwing pendable Spy that is pre-stubbed to return a pending that will block for a bit before returning Void.
+    public convenience init<Failure: Error>() where Returning == ThrowingPendable<(), Failure> {
+        self.init(.pending(fallback: .success(())))
+    }
+
+    /// Create a throwing pendable Spy that is pre-stubbed to return a pending that will block for a bit before throwing an error.
+    public convenience init<Success, Failure: Error>(pendingFailure: Failure) where Returning == ThrowingPendable<Success, Failure> {
+        self.init(.pending(fallback: .failure(pendingFailure)))
+    }
+
+    /// Create a throwing pendable Spy that is pre-stubbed to return a finished & successful value.
+    public convenience init<Success, Failure: Error>(success: Success) where Returning == ThrowingPendable<Success, Failure> {
+        self.init(.finished(.success(success)))
+    }
+
+    /// Create a throwing pendable Spy that is pre-stubbed to throw the given error.
+    public convenience init<Success, Failure: Error>(failure: Failure) where Returning == ThrowingPendable<Success, Failure> {
+        self.init(.finished(.failure(failure)))
+    }
+}
+
+extension Spy {
+    /// Update the pendable Spy's stub to be in a pending state.
+    public func stub<Success, Failure: Error>(pendingSuccess: Success) where Returning == ThrowingPendable<Success, Failure> {
+        self.stub(.pending(fallback: .success(pendingSuccess)))
+    }
+
+    /// Update the pendable Spy's stub to be in a pending state.
+    public func stub<Success, Failure: Error>(pendingFailure: Failure) where Returning == ThrowingPendable<Success, Failure> {
+        self.stub(.pending(fallback: .failure(pendingFailure)))
+    }
+
+    /// Update the throwing pendable Spy's stub to be successful, with the given value.
+    ///
+    /// - parameter success: The value to return when `callAsFunction` is called.
+    public func stub<Success, Failure: Error>(success: Success) where Returning == ThrowingPendable<Success, Failure> {
+        self.stub(.finished(.success(success)))
+    }
+
+    /// Update the throwing pendable Spy's stub to throw the given error.
+    ///
+    /// - parameter failure: The error to throw when `callAsFunction` is called.
+    public func stub<Success, Failure: Error>(failure: Failure) where Returning == ThrowingPendable<Success, Failure> {
+        self.stub(.finished(.failure(failure)))
+    }
+}
+
+extension Spy {
+    // Returning == ThrowingPendable
+    /// Records the arguments and handles the result according to ``Pendable.call(delay:)``.
+    /// This call then throws or returns the success, according to `Result.get`.
+    ///
+    /// - parameter arguments: The arguments to record.
+    /// - parameter pendingDelay: The amount of seconds to delay if the `Pendable` is .pending before
+    /// throwing a `PendableInProgressError`. If the `Pendable` is .finished, then this value is ignored.
+    public func callAsFunction<Success, Failure: Error>(
+        _ arguments: Arguments,
+        pendingDelay: TimeInterval = PendableDefaults.delay
+    ) async throws -> Success where Returning == ThrowingPendable<Success, Failure> {
+        return try await call(arguments).resolve(delay: pendingDelay)
+    }
+
+    /// Records that a call was made and handles the result according to ``Pendable.call(delay:)``.
+    /// This call then throws or returns the success, according to `Result.get`.
+    ///
+    /// - parameter pendingDelay: The amount of seconds to delay if the `Pendable` is .pending before
+    /// throwing a `PendableInProgressError`. If the `Pendable` is .finished, then this value is ignored.
+    public func callAsFunction<Success, Failure: Error>(
+        pendingDelay: TimeInterval = PendableDefaults.delay
+    ) async throws -> Success where Arguments == Void, Returning == ThrowingPendable<Success, Failure> {
+        return try await call(()).resolve(delay: pendingDelay)
+    }
+}

--- a/Sources/Fakes/Spy.swift
+++ b/Sources/Fakes/Spy.swift
@@ -37,102 +37,13 @@ public final class Spy<Arguments, Returning> {
         lock.unlock()
     }
 
-    fileprivate func call(_ arguments: Arguments) -> Returning {
+    internal func call(_ arguments: Arguments) -> Returning {
         lock.lock()
         defer { lock.unlock() }
 
         _calls.append(arguments)
 
         return _stub
-    }
-}
-
-extension Spy {
-    // MARK: - Returning Result
-    /// Create a throwing Spy that is pre-stubbed with some Success value.
-    public convenience init<Success, Failure: Error>(success: Success) where Returning == Result<Success, Failure> {
-        self.init(.success(success))
-    }
-
-    /// Create a throwing Spy that is pre-stubbed with a Void Success value
-    public convenience init<Failure: Error>() where Returning == Result<Void, Failure> {
-        self.init(.success(()))
-    }
-
-    /// Create a throwing Spy that is pre-stubbed with some Failure error.
-    public convenience init<Success, Failure: Error>(failure: Failure) where Returning == Result<Success, Failure> {
-        self.init(.failure(failure))
-    }
-
-    /// Update the throwing Spy's stub to be successful, with the given value.
-    ///
-    /// - parameter success: The success state to set the stub to, returned when `callAsFunction` is called.
-    public func stub<Success, Failure: Error>(success: Success) where Returning == Result<Success, Failure> {
-        self.stub(.success(success))
-    }
-
-    /// Update the throwing Spy's stub to be successful, with the given value.
-    ///
-    /// - parameter success: The success state to set the stub to, returned when `callAsFunction` is called.
-    public func stub<Failure: Error>() where Returning == Result<Void, Failure> {
-        self.stub(.success(()))
-    }
-
-    /// Update the throwing Spy's stub to throw the given error.
-    ///
-    /// - parameter failure: The error to throw when `callAsFunction` is called.
-    public func stub<Success, Failure: Error>(failure: Failure) where Returning == Result<Success, Failure> {
-        self.stub(.failure(failure))
-    }
-
-}
-
-extension Spy {
-    // MARK: - Returning Pendable
-    /// Create a pendable Spy that is pre-stubbed to return `.pending`.
-    public convenience init<Value>() where Returning == Pendable<Value> {
-        self.init(.pending)
-    }
-
-    /// Create a pendable Spy that is pre-stubbed to return `.finished(finished)`.
-    public convenience init<Value>(finished: Value) where Returning == Pendable<Value> {
-        self.init(.finished(finished))
-    }
-
-    /// Create a throwing pendable Spy that is pre-stubbed to return a finish & successful value.
-    public convenience init<Success, Failure: Error>(success: Success) where Returning == ThrowingPendable<Success, Failure> {
-        self.init(.finished(.success(success)))
-    }
-
-    /// Create a throwing pendable Spy that is pre-stubbed to throw the given error.
-    public convenience init<Success, Failure: Error>(failure: Failure) where Returning == ThrowingPendable<Success, Failure> {
-        self.init(.finished(.failure(failure)))
-    }
-
-    /// Update the pendable Spy's stub to be in a pending state.
-    public func stub<Value>() where Returning == Pendable<Value> {
-        self.stub(.pending)
-    }
-
-    /// Update the pendable Spy's stub to return the given value.
-    ///
-    /// - parameter finished: The value to return  when `callAsFunction` is called.
-    public func stub<Value>(finished: Value) where Returning == Pendable<Value> {
-        self.stub(.finished(finished))
-    }
-
-    /// Update the throwing pendable Spy's stub to be successful, with the given value.
-    ///
-    /// - parameter success: The value to return when `callAsFunction` is called.
-    public func stub<Success, Failure: Error>(success: Success) where Returning == ThrowingPendable<Success, Failure> {
-        self.stub(.finished(.success(success)))
-    }
-
-    /// Update the throwing pendable Spy's stub to throw the given error.
-    ///
-    /// - parameter failure: The error to throw when `callAsFunction` is called.
-    public func stub<Success, Failure: Error>(failure: Failure) where Returning == ThrowingPendable<Success, Failure> {
-        self.stub(.finished(.failure(failure)))
     }
 }
 
@@ -147,103 +58,6 @@ extension Spy {
     public func callAsFunction() -> Returning where Arguments == Void {
         return call(())
     }
-
-    // Returning == Result
-    /// Records the arguments and returns the success (or throws an error), as defined by the current stub.
-    public func callAsFunction<Success, Failure: Error>(_ arguments: Arguments) throws -> Success where Returning == Result<Success, Failure> {
-        return try call(arguments).get()
-    }
-
-    /// Records that a call was made and returns the success (or throws an error), as defined by the current stub.
-    public func callAsFunction<Success, Failure: Error>() throws -> Success where Arguments == Void, Returning == Result<Success, Failure> {
-        return try call(()).get()
-    }
-
-    // Returning == Pendable
-    /// Records the arguments and handles the result according to ``Pendable.call(delay:)``.
-    ///
-    /// - parameter arguments: The arguments to record.
-    /// - parameter pendingFallback: The value to return if the `Pendable` is .pending.
-    /// If the `Pendable` is .finished, then this value is ignored.
-    /// - parameter pendingDelay: The amount of seconds to delay if the `Pendable` is .pending before
-    /// returning the `pendingFallback`. If the `Pendable` is .finished, then this value is ignored.
-    ///
-    /// Because of how ``Pendable`` currently works, you must provide a fallback option for when the Pendable is pending.
-    /// Alternatively, you can use the throwing version of `callAsFunction`, which will thorw an error instead of returning the fallback.
-    public func callAsFunction<Value>(
-        _ arguments: Arguments,
-        pendingFallback: Value,
-        pendingDelay: TimeInterval = PendableDefaults.delay
-    ) async -> Value where Returning == Pendable<Value> {
-        return await call(arguments).resolve(pendingFallback: pendingFallback, delay: pendingDelay)
-    }
-
-    /// Records that a call was made and handles the result according to ``Pendable.call(delay:)``.
-    ///
-    /// - parameter pendingFallback: The value to return if the `Pendable` is .pending.
-    /// If the `Pendable` is .finished, then this value is ignored.
-    /// - parameter pendingDelay: The amount of seconds to delay if the `Pendable` is .pending before
-    /// returning the `pendingFallback`. If the `Pendable` is .finished, then this value is ignored.
-    ///
-    /// Because of how ``Pendable`` currently works, you must provide a fallback option for when the Pendable is pending.
-    /// Alternatively, you can use the throwing version of `callAsFunction`, which will thorw an error instead of returning the fallback.
-    public func callAsFunction<Value>(
-        pendingFallback: Value,
-        pendingDelay: TimeInterval = PendableDefaults.delay
-    ) async -> Value where Arguments == Void, Returning == Pendable<Value> {
-        return await call(()).resolve(pendingFallback: pendingFallback, delay: pendingDelay)
-    }
-
-    /// Records the arguments and handles the result according to ``Pendable.call(delay:)``.
-    ///
-    /// - parameter arguments: The arguments to record.
-    /// - parameter pendingDelay: The amount of seconds to delay if the `Pendable` is .pending before
-    /// throwing a `PendableInProgressError`. If the `Pendable` is .finished, then this value is ignored.
-    public func callAsFunction<Value>(
-        _ arguments: Arguments,
-        pendingDelay: TimeInterval = PendableDefaults.delay
-    ) async throws -> Value where Returning == Pendable<Value> {
-        return try await call(arguments).resolve(delay: pendingDelay)
-    }
-
-    /// Records that a call was made and handles the result according to ``Pendable.call(delay:)``.
-    ///
-    /// - parameter pendingDelay: The amount of seconds to delay if the `Pendable` is .pending before
-    /// throwing a `PendableInProgressError`. If the `Pendable` is .finished, then this value is ignored.
-    public func callAsFunction<Value>(
-        pendingDelay: TimeInterval = PendableDefaults.delay
-    ) async throws -> Value where Arguments == Void, Returning == Pendable<Value> {
-        return try await call(()).resolve(delay: pendingDelay)
-    }
-
-    // Returning == ThrowingPendable
-    /// Records the arguments and handles the result according to ``Pendable.call(delay:)``.
-    /// This call then throws or returns the success, according to `Result.get`.
-    ///
-    /// - parameter arguments: The arguments to record.
-    /// - parameter pendingDelay: The amount of seconds to delay if the `Pendable` is .pending before
-    /// throwing a `PendableInProgressError`. If the `Pendable` is .finished, then this value is ignored.
-    public func callAsFunction<Success, Failure: Error>(
-        _ arguments: Arguments,
-        pendingDelay: TimeInterval = PendableDefaults.delay
-    ) async throws -> Success where Returning == ThrowingPendable<Success, Failure> {
-        return try await call(arguments).resolve(delay: pendingDelay)
-    }
-
-    /// Records that a call was made and handles the result according to ``Pendable.call(delay:)``.
-    /// This call then throws or returns the success, according to `Result.get`.
-    ///
-    /// - parameter pendingDelay: The amount of seconds to delay if the `Pendable` is .pending before
-    /// throwing a `PendableInProgressError`. If the `Pendable` is .finished, then this value is ignored.
-    public func callAsFunction<Success, Failure: Error>(
-        pendingDelay: TimeInterval = PendableDefaults.delay
-    ) async throws -> Success where Arguments == Void, Returning == ThrowingPendable<Success, Failure> {
-        return try await call(()).resolve(delay: pendingDelay)
-    }
 }
 
 extension Spy: @unchecked Sendable where Arguments: Sendable, Returning: Sendable {}
-
-public typealias ThrowingSpy<Arguments, Success, Failure: Error> = Spy<Arguments, Result<Success, Failure>>
-public typealias PendableSpy<Arguments, Value> = Spy<Arguments, Pendable<Value>>
-public typealias ThrowingPendableSpy<Arguments, Success, Failure: Error> = Spy<Arguments, ThrowingPendable<Success, Failure>>

--- a/Tests/FakesTests/SpyTests.swift
+++ b/Tests/FakesTests/SpyTests.swift
@@ -91,33 +91,33 @@ final class SpyTests: XCTestCase {
     }
 
     func testPendable() async {
-        let subject = PendableSpy<Void, Int>()
+        let subject = PendableSpy<Void, Int>(pendingFallback: 1)
 
         await expect {
-            try await subject(pendingDelay: 0)
-        }.toEventually(throwError(PendableInProgressError()))
+            await subject(pendingDelay: 0)
+        }.toEventually(equal(1))
 
         subject.stub(finished: 4)
 
         await expect {
-            try await subject(pendingDelay: 0)
+            await subject(pendingDelay: 0)
         }.toEventually(equal(4))
     }
 
     func testPendableTakesNonVoidArguments() async throws {
         let subject = PendableSpy<Int, Void>(finished: ())
 
-        try await subject(3, pendingDelay: 0)
+        await subject(3, pendingDelay: 0)
 
         expect(subject.calls).to(equal([3]))
     }
 
     func testThrowingPendable() async {
-        let subject = ThrowingPendableSpy<Void, Int, TestError>()
+        let subject = ThrowingPendableSpy<Void, Int, TestError>(pendingSuccess: 0)
 
         await expect {
             try await subject(pendingDelay: 0)
-        }.toEventually(throwError(PendableInProgressError()))
+        }.toEventually(equal(0))
 
         subject.stub(success: 5)
 


### PR DESCRIPTION
This also splits the implementation of Spy across multiple files.

`Pendable` (which will likely be renamed to `StaticPendable` shortly) should really have the pending fallback value be set at creation time, instead of when `resolve` is called.

I'll definitely need to write up documentation on the challenges of testing async functions.

- This is a breaking change, which would require us to update the major version if we were post 1.0.
