### PR TITLE
Add method to clear the recorded calls from the spy

### DIFF
--- a/Sources/Fakes/Spy.swift
+++ b/Sources/Fakes/Spy.swift
@@ -27,6 +27,16 @@ public final class Spy<Arguments, Returning> {
         self.init(())
     }
 
+    /// Clear out existing call records.
+    ///
+    /// This removes all previously recorded calls from the spy. It does not otherwise
+    /// mutate the spy.
+    public func clearCalls() {
+        lock.lock()
+        _calls = []
+        lock.unlock()
+    }
+
     // MARK: Stubbing
     /// Update the Spy's stub to return the given value.
     ///

--- a/Tests/FakesTests/SpyTests.swift
+++ b/Tests/FakesTests/SpyTests.swift
@@ -138,6 +138,16 @@ final class SpyTests: XCTestCase {
 
         expect(subject.calls).to(equal([8]))
     }
+
+    func testClearCalls() {
+        let subject = Spy<Int, Void>()
+
+        subject(1)
+        subject(2)
+
+        subject.clearCalls()
+        expect(subject.calls).to(beEmpty())
+    }
 }
 
 enum TestError: Error {


### PR DESCRIPTION
Sometimes, it's useful to be able to clear the call history from a spy.

My use case for this is: you've previously asserted that a spy is called, but you want to make sure it's not called again afterwards. Sure, you could grab the current call count and then assert that it doesn't change. But it reads better to clear the call history, and assert that it's not been called.

Compare:

```swift
// when calling `doSomething()` twice, it does not call `method` more than once.
subject.doSomething()

expect(someFake.methodSpy).to(beCalled())
let currentCallCount = someFake.methodSpy.calls.count

subject.doSomething()

expect(someFake.methodSpy).to(beCalled(times: currentCallCount))
```

to:

```swift
subject.doSomething()

expect(someFake.methodSpy).to(beCalled())
someFake.methodSpy.clearCalls()

subject.doSomething()

expect(someFake.methodSpy).toNot(beCalled())
```