### PR TITLE
Provide default initializers for Spy when throwing any Swift.Error

### DIFF
--- a/Sources/Fakes/EmptyError.swift
+++ b/Sources/Fakes/EmptyError.swift
@@ -1,0 +1,4 @@
+/// An error that can be used as a default error in tests
+public struct EmptyError: Error, Sendable {
+    public init() {}
+}

--- a/Sources/Fakes/Pendable/Pendable.swift
+++ b/Sources/Fakes/Pendable/Pendable.swift
@@ -184,9 +184,6 @@ extension Pendable {
 
     /// Creatse a new pending `Pendable` with a fallback value of an error.
     public static func pending<Success>() -> Pendable<Value> where Value == Result<Success, Error> {
-        Pendable(fallbackValue: Result<Success, Error>.failure(PendableDefaultError()))
+        Pendable(fallbackValue: Result<Success, Error>.failure(EmptyError()))
     }
 }
-
-/// An error that can be used as a default error for ``Pendable`` when returning a `Result<..., Error>`.
-public struct PendableDefaultError: Error, Sendable {}

--- a/Sources/Fakes/Spy/Spy+Result.swift
+++ b/Sources/Fakes/Spy/Spy+Result.swift
@@ -15,6 +15,10 @@ extension Spy {
     public convenience init<Success, Failure: Error>(failure: Failure) where Returning == Result<Success, Failure> {
         self.init(.failure(failure))
     }
+
+    public convenience init<Success>() where Returning == Result<Success, Error> {
+        self.init(.failure(EmptyError()))
+    }
 }
 
 extension Spy {

--- a/Sources/Fakes/Spy/Spy+ThrowingPendable.swift
+++ b/Sources/Fakes/Spy/Spy+ThrowingPendable.swift
@@ -18,6 +18,11 @@ extension Spy {
         self.init(.pending(fallback: .failure(pendingFailure)))
     }
 
+    /// Create a throwing pendable Spy that is pre-stubbed to return a pending that will block for a bit before throwing an error
+    public convenience init<Success: Sendable>() where Returning == ThrowingPendable<Success, Error> {
+        self.init(.pending(fallback: .failure(EmptyError())))
+    }
+
     /// Create a throwing pendable Spy that is pre-stubbed to return a finished & successful value.
     public convenience init<Success: Sendable, Failure: Error>(success: Success) where Returning == ThrowingPendable<Success, Failure> {
         self.init(.finished(.success(success)))
@@ -54,7 +59,7 @@ extension Spy {
 
     /// Update the pendable Spy's stub to be in a pending state with a default failure value.
     public func stubPendingFailure<Success: Sendable>() where Returning == ThrowingPendable<Success, Error> {
-        self.stub(pendingFailure: PendableDefaultError())
+        self.stub(pendingFailure: EmptyError())
     }
 
     /// Update the throwing pendable Spy's stub to be successful, with the given value.
@@ -73,7 +78,7 @@ extension Spy {
 
     /// Update the throwing pendable Spy's stub to throw an error.
     public func stubFailure<Success: Sendable>() where Returning == ThrowingPendable<Success, Error> {
-        self.stub(failure: PendableDefaultError())
+        self.stub(failure: EmptyError())
     }
 }
 


### PR DESCRIPTION
Rename PendableDefaultError to EmptyError, and make its initializer public
