### PR TITLE
Support dynamic responses in Spy

### DIFF
--- a/.github/workflows/ci-swiftpm.yml
+++ b/.github/workflows/ci-swiftpm.yml
@@ -23,10 +23,10 @@ jobs:
   swiftpm_darwin:
     name: SwiftPM, Darwin, Xcode ${{ matrix.xcode }}
     needs: filter
-    runs-on: macos-12
+    runs-on: macos-14
     strategy:
       matrix:
-        xcode: ["14.0.1"]
+        xcode: ["15.3", "16.1"]
       fail-fast: false
     env:
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode }}.app"
@@ -45,10 +45,9 @@ jobs:
     strategy:
       matrix:
         container:
-          - swift:5.7
-          - swift:5.8
           - swift:5.9
           - swift:5.10
+          - swift:6.0
       fail-fast: false
     container: ${{ matrix.container }}
     steps:

--- a/Sources/Fakes/DynamicResult.swift
+++ b/Sources/Fakes/DynamicResult.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+/// A DynamicResult is specifically for mocking out when multiple results for a call can happen.
+///
+/// DynamicResult is intended to be an implementation detail of ``Spy``,
+/// but is exposed publicly to be composed with other types as desired.
+public final class DynamicResult<Arguments, Returning> {
+    /// A value or closure to be used by the DynamicResult
+    public enum Stub {
+        /// A static value
+        case value(Returning)
+        /// A closure to be called.
+        case closure(@Sendable (Arguments) -> Returning)
+
+        /// Call the stub.
+        /// If the stub is a `.value`, then return the value.
+        /// If the stub is a `.closure`, then call the closure with the arguments.
+        func call(_ arguments: Arguments) -> Returning {
+            switch self {
+            case .value(let returning):
+                return returning
+            case .closure(let closure):
+                return closure(arguments)
+            }
+        }
+    }
+
+    private let lock = NSRecursiveLock()
+    private var stubs: [Stub]
+
+    private var _stubHistory: [Returning] = []
+    var stubHistory: [Returning] {
+        lock.lock()
+        defer { lock.unlock () }
+        return _stubHistory
+    }
+
+    /// Create a new DynamicResult stubbed to return the values in the given order.
+    /// That is, given `DynamicResult<Void, Int>(1, 2, 3)`,
+    /// if you call `.call` 5 times, you will get back `1, 2, 3, 3, 3`.
+    public init(_ value: Returning, _ values: Returning...) {
+        self.stubs = Array(value, values).map { Stub.value($0) }
+    }
+
+    internal init(_ values: [Returning]) {
+        self.stubs = values.map { Stub.value($0) }
+    }
+
+    /// Create a new DynamicResult stubbed to call the given closure.
+    public init(_ closure: @escaping @Sendable (Arguments) -> Returning) {
+        self.stubs = [.closure(closure)]
+    }
+
+    /// Create a new DynamicResult stubbed to call the given stubs.
+    public init(_ stub: Stub, _ stubs: Stub...) {
+        self.stubs = Array(stub, stubs)
+    }
+
+    internal init(_ stubs: [Stub]) {
+        self.stubs = stubs
+    }
+
+    /// Call the DynamicResult, returning the next stub in the list of stubs.
+    public func call(_ arguments: Arguments) -> Returning {
+        lock.lock()
+        defer { lock.unlock () }
+        let value = nextStub().call(arguments)
+        _stubHistory.append(value)
+        return value
+    }
+
+    /// Call the DynamicResult, returning the next stub in the list of stubs.
+    public func call() -> Returning where Arguments == Void {
+        call(())
+    }
+
+    /// Replace the stubs with the new static values
+    public func replace(_ value: Returning, _ values: Returning...) {
+        replace(Array(value, values))
+    }
+
+    /// Replace the stubs with the new static values
+    internal func replace(_ values: [Returning]) {
+        lock.lock()
+        defer { lock.unlock () }
+        self.resolvePendables()
+        self.stubs = values.map { .value($0) }
+    }
+
+    /// Replace the stubs with the new closure.
+    public func replace(_ closure: @escaping @Sendable (Arguments) -> Returning) {
+        lock.lock()
+        defer { lock.unlock () }
+        self.resolvePendables()
+        self.stubs = [.closure(closure)]
+    }
+
+    /// Replace the stubs with the new list of stubs
+    public func replace(_ stub: Stub, _ stubs: Stub...) {
+        lock.lock()
+        defer { lock.unlock () }
+        self.resolvePendables()
+        self.stubs = Array(stub, stubs)
+    }
+
+    /// Replace the stubs with the new list of stubs
+    internal func replace(_ stubs: [Stub]) {
+        lock.lock()
+        defer { lock.unlock () }
+        self.resolvePendables()
+        self.stubs = stubs
+    }
+
+    /// Append the values to the list of stubs.
+    public func append(_ value: Returning, _ values: Returning...) {
+        append(Array(value, values))
+    }
+
+    internal func append(_ values: [Returning]) {
+        lock.lock()
+        defer { lock.unlock () }
+        stubs.append(contentsOf: values.map { .value($0) })
+    }
+
+    /// Append the closure to the list of stubs.
+    public func append(_ closure: @escaping @Sendable (Arguments) -> Returning) {
+        lock.lock()
+        defer { lock.unlock () }
+        stubs.append(.closure(closure))
+    }
+
+    /// Append the stubs to the list of stubs.
+    public func append(_ stub: Stub, _ stubs: Stub...) {
+        append(Array(stub, stubs))
+    }
+
+    internal func append(_ stubs: [Stub]) {
+        lock.lock()
+        defer { lock.unlock () }
+        self.stubs.append(contentsOf: stubs)
+    }
+
+    private func nextStub() -> Stub {
+        guard let stub = stubs.first else {
+            fatalError("Fakes: DynamicResult \(self) has 0 stubs. This should never happen. File a bug at https://github.com/Quick/swift-fakes/issues/new")
+        }
+        if stubs.count > 1 {
+            stubs.removeFirst()
+        }
+        return stub
+    }
+
+    private func resolvePendables() {
+        stubs.forEach {
+            guard case .value(let value) = $0 else { return }
+            if let resolvable = value as? ResolvableWithFallback {
+                resolvable.resolveWithFallback()
+            }
+        }
+    }
+}
+
+extension DynamicResult: @unchecked Sendable where Arguments: Sendable, Returning: Sendable {}
+
+internal extension Array {
+    init(_ value: Element, _ values: [Element]) {
+        self = [value] + values
+    }
+
+    mutating func append(_ value: Element, _ values: [Element]) {
+        self.append(contentsOf: Array(value, values))
+    }
+}

--- a/Sources/Fakes/Spy/Spy+Pendable.swift
+++ b/Sources/Fakes/Spy/Spy+Pendable.swift
@@ -1,6 +1,12 @@
 import Foundation
 
-public typealias PendableSpy<Arguments, Value> = Spy<Arguments, Pendable<Value>>
+public typealias PendableSpy<
+    Arguments,
+    Value
+> = Spy<
+    Arguments,
+    Pendable<Value>
+>
 
 extension Spy {
     /// Create a pendable Spy that is pre-stubbed to return return a a pending that will block for a bit before returning the fallback value.

--- a/Sources/Fakes/Spy/Spy+ThrowingPendable.swift
+++ b/Sources/Fakes/Spy/Spy+ThrowingPendable.swift
@@ -1,6 +1,18 @@
 import Foundation
 
-public typealias ThrowingPendableSpy<Arguments, Success, Failure: Error> = Spy<Arguments, ThrowingPendable<Success, Failure>>
+public typealias ThrowingPendableSpy<
+    Arguments,
+    Success,
+    Failure: Error
+> = Spy<
+    Arguments,
+    Pendable<
+        Result<
+            Success,
+            Failure
+        >
+    >
+>
 
 extension Spy {
     /// Create a throwing pendable Spy that is pre-stubbed to return a pending that will block for a bit before returning success.

--- a/Sources/Fakes/Spy/Spy.swift
+++ b/Sources/Fakes/Spy/Spy.swift
@@ -5,6 +5,8 @@ import Foundation
 /// Spies should be used to verify that Fakes are called correctly, and to provide pre-stubbed values
 /// that the Fake returns to the caller.
 public final class Spy<Arguments, Returning> {
+    public typealias Stub = DynamicResult<Arguments, Returning>.Stub
+
     private let lock = NSRecursiveLock()
 
     private var _calls: [Arguments] = []
@@ -14,12 +16,28 @@ public final class Spy<Arguments, Returning> {
         return _calls
     }
 
-    private var _stub: Returning
+    private var _stub: DynamicResult<Arguments, Returning>
 
     // MARK: - Initializers
-    /// Create a Spy with the given stubbed value.
-    public init(_ stub: Returning) {
-        _stub = stub
+    /// Create a Spy with the given stubbed values.
+    public init(_ value: Returning, _ values: Returning...) {
+        _stub = DynamicResult(Array(value, values))
+    }
+
+    internal init(_ values: [Returning]) {
+        _stub = DynamicResult(values)
+    }
+
+    public init(_ closure: @escaping @Sendable (Arguments) -> Returning) {
+        _stub = DynamicResult(closure)
+    }
+
+    public init(_ stub: Stub, _ stubs: Stub...) {
+        _stub = DynamicResult(Array(stub, stubs))
+    }
+
+    internal init(_ stubs: [Stub]) {
+        _stub = DynamicResult(stubs)
     }
 
     /// Create a Spy that returns Void
@@ -39,22 +57,83 @@ public final class Spy<Arguments, Returning> {
     /// mutate the spy.
     public func clearCalls() {
         lock.lock()
+        defer { lock.unlock () }
         _calls = []
-        lock.unlock()
     }
 
     // MARK: Stubbing
-    /// Update the Spy's stub to return the given value.
+    /// Replaces the Spy's stubs with the given values.
     ///
-    /// - parameter value: The value to return when `callAsFunction()` is called.
-    public func stub(_ value: Returning) {
-        lock.lock()
+    /// - parameter value: The first value to return when `callAsFunction()` is called.
+    /// - parameter values: The list of other values (in order) to return when `callAsFunction()` is called.
+    ///
+    /// - Note: This resolves any pending Pendables during replacement.
+    public func stub(_ value: Returning, _ values: Returning...) {
+        stub(Array(value, values))
+    }
 
-        if let resolvable = _stub as? ResolvableWithFallback {
-            resolvable.resolveWithFallback()
-        }
-        _stub = value
-        lock.unlock()
+    internal func stub(_ values: [Returning]) {
+        lock.lock()
+        defer { lock.unlock () }
+        _stub.replace(values)
+    }
+
+    /// Replaces the Spy's stubs with the given closure.
+    ///
+    /// - parameter closure: The closure to call with the arguments when `callAsFunction()` is called.
+    ///
+    /// - Note: This resolves any pending Pendables during replacement.
+    public func stub(_ closure: @escaping @Sendable (Arguments) -> Returning) {
+        lock.lock()
+        defer { lock.unlock () }
+        _stub.replace(closure)
+    }
+
+    /// Replace the Spy's stubs with the new list of stubs
+    ///
+    /// - parameter stub: The first stub to call when `callAsFunction()` is called.
+    /// - parameter stubs: The list of other stubs (in order) to return when `callAsFunction()` is called.
+    ///
+    /// - Note: This resolves any pending Pendables during replacement.
+    public func replace(
+        _ stub: Stub,
+        _ stubs: Stub...
+    ) {
+        lock.lock()
+        defer { lock.unlock () }
+        _stub.replace(Array(stub, stubs))
+    }
+
+    /// Append the values to the Spy's stubs
+    ///
+    /// - parameter value: The first value to append to the list of stubs
+    /// - parameter values: The remaining values to append to the list of stubs
+    public func append(_ value: Returning, _ values: Returning...) {
+        lock.lock()
+        defer { lock.unlock () }
+        _stub.append(Array(value, values))
+    }
+
+    /// Append the closure to the list of Spy's stubs
+    ///
+    /// - parameter closure: The new closure to call at the end of the list of stubs
+    public func append(_ closure: @escaping @Sendable (Arguments) -> Returning) {
+        lock.lock()
+        defer { lock.unlock () }
+        _stub.append(closure)
+    }
+
+    /// Append the stubs to the list of stubs.
+    ///
+    /// - parameter value: The first stub to append to the list of stubs
+    /// - parameter values: The remaining stubs to append to the list of stubs
+    public func append(
+        _ stub: Stub,
+        _ stubs: Stub...
+    ) {
+        lock.lock()
+        defer { lock.unlock () }
+        _stub.append(Array(stub, stubs))
     }
 
     internal func call(_ arguments: Arguments) -> Returning {
@@ -63,7 +142,7 @@ public final class Spy<Arguments, Returning> {
 
         _calls.append(arguments)
 
-        return _stub
+        return _stub.call(arguments)
     }
 }
 
@@ -84,7 +163,9 @@ extension Spy {
     public func resolveStub<Value>(with value: Value) where Returning == Pendable<Value> {
         lock.lock()
         defer { lock.unlock() }
-        _stub.resolve(with: value)
+        _stub.stubHistory.forEach {
+            $0.resolve(with: value)
+        }
     }
 }
 

--- a/Tests/FakesTests/DynamicResultTests.swift
+++ b/Tests/FakesTests/DynamicResultTests.swift
@@ -1,0 +1,132 @@
+import Fakes
+import Nimble
+import XCTest
+
+final class DynamicResultTests: XCTestCase {
+    func testSingleStaticValue() {
+        let subject = DynamicResult<Int, Int>(1)
+
+        expect(subject.call(1)).to(equal(1))
+        expect(subject.call(1)).to(equal(1))
+        expect(subject.call(1)).to(equal(1))
+    }
+
+    func testMultipleStaticValues() {
+        let subject = DynamicResult<Void, Int>(1, 2, 3)
+
+        expect(subject.call()).to(equal(1))
+        expect(subject.call()).to(equal(2))
+        expect(subject.call()).to(equal(3))
+        // After the last call, we continue to return the last stub in the list
+        expect(subject.call()).to(equal(3))
+        expect(subject.call()).to(equal(3))
+    }
+
+    func testClosure() {
+        let subject = DynamicResult<Int, Int>({ $0 + 1 })
+
+        expect(subject.call(1)).to(equal(2))
+        expect(subject.call(2)).to(equal(3))
+        expect(subject.call(3)).to(equal(4))
+    }
+
+    func testStubs() {
+        let subject = DynamicResult<Int, Int>(
+            .value(1),
+            .closure({ $0 * 3}),
+            .value(4)
+        )
+
+        expect(subject.call(1)).to(equal(1))
+        expect(subject.call(2)).to(equal(6))
+        expect(subject.call(3)).to(equal(4))
+        expect(subject.call(3)).to(equal(4))
+    }
+
+    // MARK: - Replacement Tests
+
+    func testReplacementStaticValue() {
+        let subject = DynamicResult<Void, Int>(1)
+
+        subject.replace(2, 3, 4, 6)
+
+        expect(subject.call()).to(equal(2))
+        expect(subject.call()).to(equal(3))
+        expect(subject.call()).to(equal(4))
+        expect(subject.call()).to(equal(6))
+        // After the last call, we continue to return the last stub in the list
+        expect(subject.call()).to(equal(6))
+    }
+
+    func testReplacementClosure() {
+        let subject = DynamicResult<Int, Int>(1)
+
+        subject.replace({ $0 + 4})
+
+        expect(subject.call(1)).to(equal(5))
+        expect(subject.call(2)).to(equal(6))
+        expect(subject.call(3)).to(equal(7))
+    }
+
+    func testReplacementStubs() {
+        let subject = DynamicResult<Int, Int>(1)
+
+        subject.replace(
+            .value(2),
+            .closure({ $0 * 3}),
+            .value(4)
+        )
+
+        expect(subject.call(1)).to(equal(2))
+        expect(subject.call(2)).to(equal(6))
+        expect(subject.call(3)).to(equal(4))
+        expect(subject.call(3)).to(equal(4))
+    }
+
+    // MARK: - Appending Tests
+
+    func testAppendingStaticValue() {
+        let subject = DynamicResult<Void, Int>(1, 2, 3)
+
+        subject.append(4, 5, 6)
+
+        expect(subject.call()).to(equal(1))
+        expect(subject.call()).to(equal(2))
+        expect(subject.call()).to(equal(3))
+        expect(subject.call()).to(equal(4))
+        expect(subject.call()).to(equal(5))
+        expect(subject.call()).to(equal(6))
+        // After the last call, we continue to return the last stub in the list
+        expect(subject.call()).to(equal(6))
+    }
+
+    func testAppendingClosure() {
+        let subject = DynamicResult<Int, Int>(1, 2, 3)
+
+        subject.append({ $0 + 10})
+
+        expect(subject.call(1)).to(equal(1))
+        expect(subject.call(2)).to(equal(2))
+        expect(subject.call(3)).to(equal(3))
+        expect(subject.call(4)).to(equal(14))
+        expect(subject.call(5)).to(equal(15))
+    }
+
+    func testAppendingStubs() {
+        let subject = DynamicResult<Int, Int>(1, 2, 3)
+
+        subject.append(
+            .value(4),
+            .closure({ $0 * 3}),
+            .value(6)
+        )
+
+        expect(subject.call(1)).to(equal(1))
+        expect(subject.call(2)).to(equal(2))
+        expect(subject.call(3)).to(equal(3))
+        expect(subject.call(4)).to(equal(4))
+        expect(subject.call(5)).to(equal(15))
+        expect(subject.call(6)).to(equal(6))
+        expect(subject.call(7)).to(equal(6))
+    }
+}

--- a/Tests/FakesTests/SpyTests.swift
+++ b/Tests/FakesTests/SpyTests.swift
@@ -39,6 +39,44 @@ final class SpyTests: XCTestCase {
         }.to(equal(456))
     }
 
+    func testMultipleStubs() {
+        let subject = Spy<Void, Int>(1, 2, 3)
+
+        expect(subject()).to(equal(1))
+        expect(subject()).to(equal(2))
+        expect(subject()).to(equal(3))
+        expect(subject()).to(equal(3))
+    }
+
+    func testClosureStubs() {
+        let subject = Spy<Int, Int> { $0 }
+
+        expect(subject(1)).to(equal(1))
+        expect(subject(2)).to(equal(2))
+        expect(subject(3)).to(equal(3))
+        expect(subject(10)).to(equal(10))
+    }
+
+    func testReplacingStubs() {
+        let subject = Spy<Void, Int>(5)
+        subject.stub(1, 2, 3)
+
+        expect(subject()).to(equal(1))
+        expect(subject()).to(equal(2))
+        expect(subject()).to(equal(3))
+        expect(subject()).to(equal(3))
+    }
+
+    func testReplacingClosures() {
+        let subject = Spy<Int, Int>(5)
+        subject.stub { $0 }
+
+        expect(subject(1)).to(equal(1))
+        expect(subject(2)).to(equal(2))
+        expect(subject(3)).to(equal(3))
+        expect(subject(10)).to(equal(10))
+    }
+
     func testResult() {
         let subject = Spy<Void, Result<Int, TestError>>(.failure(TestError.uhOh))
 


### PR DESCRIPTION
Adds a new type: DynamicResult, which encapsulates handling multiple responses, as well as side effects/closures Updates Spy to use DynamicResult internally, though document DynamicResult for those who wish to use it directly.

Resolves #3 #4

Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [x] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [x] Is this a new feature (Requires minor version bump)?
