### PR TITLE
Add Android test CI

### DIFF
--- a/.github/workflows/ci-swiftpm.yml
+++ b/.github/workflows/ci-swiftpm.yml
@@ -57,3 +57,12 @@ jobs:
         if: ${{ needs.filter.outputs.should_skip != 'true' }}
       - run: swift test
         if: ${{ needs.filter.outputs.should_skip != 'true' }}
+
+  swiftpm_android:
+    name: SwiftPM, Android
+    needs: filter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: skiptools/swift-android-action@v2
+


### PR DESCRIPTION
This PR adds Android CI support using the [swift-android-action](https://github.com/marketplace/actions/swift-android-action), which will cross-compile and test the library against an Android emulator on an Ubuntu runner.