### PR TITLE
Use swift package traits to make Nimble an optional component.

### DIFF
--- a/.github/workflows/ci-swiftpm.yml
+++ b/.github/workflows/ci-swiftpm.yml
@@ -37,6 +37,8 @@ jobs:
         if: ${{ needs.filter.outputs.should_skip != 'true' }}
       - run: swift test
         if: ${{ needs.filter.outputs.should_skip != 'true' }}
+      - run: swift test --traits Include_Nimble
+        if: ${{ needs.filter.outputs.should_skip != 'true' }}
 
   swiftpm_darwin_15:
     name: SwiftPM, Darwin 15, Xcode ${{ matrix.xcode }}
@@ -54,6 +56,8 @@ jobs:
       - run: swift build
         if: ${{ needs.filter.outputs.should_skip != 'true' }}
       - run: swift test
+        if: ${{ needs.filter.outputs.should_skip != 'true' }}
+      - run: swift test --traits Include_Nimble
         if: ${{ needs.filter.outputs.should_skip != 'true' }}
 
   swiftpm_linux:
@@ -74,6 +78,8 @@ jobs:
       - run: swift build
         if: ${{ needs.filter.outputs.should_skip != 'true' }}
       - run: swift test
+        if: ${{ needs.filter.outputs.should_skip != 'true' }}
+      - run: swift test --traits Include_Nimble
         if: ${{ needs.filter.outputs.should_skip != 'true' }}
 
   swiftpm_android:

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5bc9c42a661634bd36bc39a230eb3807665c4762f9170c426c649f738d2edde6",
+  "originHash" : "5da7f878f5b1139f894b982a52fd7488eb9f2b260e6e914101cd9937e8b6941a",
   "pins" : [
     {
       "identity" : "cwlcatchexception",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
-        "version" : "1.4.5"
+        "revision" : "85e4bb4e1cd62cec64a4b8e769dcefdf0c5b9d64",
+        "version" : "1.4.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,14 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 
 import PackageDescription
 
 let package = Package(
     name: "swift-fakes",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .visionOS(.v1)
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .visionOS(.v1)
     ],
     products: [
         .library(
@@ -13,21 +16,48 @@ let package = Package(
             targets: ["Fakes"]
         ),
     ],
+    traits: [
+        .init(
+            name: "Include_Nimble",
+            description: "Enable Nimble Integration",
+            enabledTraits: []
+        ),
+    ],
     dependencies: [
-        .package(url:  "https://github.com/Quick/Nimble.git", from: "14.0.0"),
+        .package(
+            url:  "https://github.com/Quick/Nimble.git",
+            from: "14.0.0"
+        ),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         .target(
             name: "Fakes",
-            dependencies: ["Nimble"],
+            dependencies: [
+                .product(
+                    name: "Nimble",
+                    package: "Nimble",
+                    condition: .when(
+                        traits: ["Include_Nimble"]
+                    )
+                )
+            ],
             resources: [
                 .copy("PrivacyInfo.xcprivacy")
             ]
         ),
         .testTarget(
             name: "FakesTests",
-            dependencies: ["Fakes", "Nimble"]
+            dependencies: [
+                "Fakes",
+                .product(
+                    name: "Nimble",
+                    package: "Nimble",
+                    condition: .when(
+                        traits: ["Include_Nimble"]
+                    )
+                )
+            ]
         ),
     ]
 )

--- a/Sources/Fakes/Spy/Spy+Nimble.swift
+++ b/Sources/Fakes/Spy/Spy+Nimble.swift
@@ -1,3 +1,4 @@
+#if Include_Nimble
 import Nimble
 
 // MARK: - Verifying any calls to the Spy.
@@ -303,3 +304,4 @@ private func _mostRecentlyBeCalled<Arguments, Returning>(
         )
     }
 }
+#endif

--- a/Tests/FakesTests/DynamicResultTests.swift
+++ b/Tests/FakesTests/DynamicResultTests.swift
@@ -1,74 +1,73 @@
 import Fakes
-import Nimble
-import XCTest
+import Testing
 
-final class DynamicResultTests: XCTestCase {
-    func testSingleStaticValue() {
+struct DynamicResultTests {
+    @Test func testSingleStaticValue() {
         let subject = DynamicResult<Int, Int>(1)
 
-        expect(subject.call(1)).to(equal(1))
-        expect(subject.call(1)).to(equal(1))
-        expect(subject.call(1)).to(equal(1))
+        #expect(subject.call(1) == 1)
+        #expect(subject.call(1) == 1)
+        #expect(subject.call(1) == 1)
     }
 
-    func testMultipleStaticValues() {
+    @Test func testMultipleStaticValues() {
         let subject = DynamicResult<Void, Int>(1, 2, 3)
 
-        expect(subject.call()).to(equal(1))
-        expect(subject.call()).to(equal(2))
-        expect(subject.call()).to(equal(3))
+        #expect(subject.call() == 1)
+        #expect(subject.call() == 2)
+        #expect(subject.call() == 3)
         // After the last call, we continue to return the last stub in the list
-        expect(subject.call()).to(equal(3))
-        expect(subject.call()).to(equal(3))
+        #expect(subject.call() == 3)
+        #expect(subject.call() == 3)
     }
 
-    func testClosure() {
+    @Test func testClosure() {
         let subject = DynamicResult<Int, Int>({ $0 + 1 })
 
-        expect(subject.call(1)).to(equal(2))
-        expect(subject.call(2)).to(equal(3))
-        expect(subject.call(3)).to(equal(4))
+        #expect(subject.call(1) == 2)
+        #expect(subject.call(2) == 3)
+        #expect(subject.call(3) == 4)
     }
 
-    func testStubs() {
+    @Test func testStubs() {
         let subject = DynamicResult<Int, Int>(
             .value(1),
             .closure({ $0 * 3}),
             .value(4)
         )
 
-        expect(subject.call(1)).to(equal(1))
-        expect(subject.call(2)).to(equal(6))
-        expect(subject.call(3)).to(equal(4))
-        expect(subject.call(3)).to(equal(4))
+        #expect(subject.call(1) == 1)
+        #expect(subject.call(2) == 6)
+        #expect(subject.call(3) == 4)
+        #expect(subject.call(3) == 4)
     }
 
     // MARK: - Replacement Tests
 
-    func testReplacementStaticValue() {
+    @Test func testReplacementStaticValue() {
         let subject = DynamicResult<Void, Int>(1)
 
         subject.replace(2, 3, 4, 6)
 
-        expect(subject.call()).to(equal(2))
-        expect(subject.call()).to(equal(3))
-        expect(subject.call()).to(equal(4))
-        expect(subject.call()).to(equal(6))
+        #expect(subject.call() == 2)
+        #expect(subject.call() == 3)
+        #expect(subject.call() == 4)
+        #expect(subject.call() == 6)
         // After the last call, we continue to return the last stub in the list
-        expect(subject.call()).to(equal(6))
+        #expect(subject.call() == 6)
     }
 
-    func testReplacementClosure() {
+    @Test func testReplacementClosure() {
         let subject = DynamicResult<Int, Int>(1)
 
         subject.replace({ $0 + 4})
 
-        expect(subject.call(1)).to(equal(5))
-        expect(subject.call(2)).to(equal(6))
-        expect(subject.call(3)).to(equal(7))
+        #expect(subject.call(1) == 5)
+        #expect(subject.call(2) == 6)
+        #expect(subject.call(3) == 7)
     }
 
-    func testReplacementStubs() {
+    @Test func testReplacementStubs() {
         let subject = DynamicResult<Int, Int>(1)
 
         subject.replace(
@@ -77,42 +76,42 @@ final class DynamicResultTests: XCTestCase {
             .value(4)
         )
 
-        expect(subject.call(1)).to(equal(2))
-        expect(subject.call(2)).to(equal(6))
-        expect(subject.call(3)).to(equal(4))
-        expect(subject.call(3)).to(equal(4))
+        #expect(subject.call(1) == 2)
+        #expect(subject.call(2) == 6)
+        #expect(subject.call(3) == 4)
+        #expect(subject.call(3) == 4)
     }
 
     // MARK: - Appending Tests
 
-    func testAppendingStaticValue() {
+    @Test func testAppendingStaticValue() {
         let subject = DynamicResult<Void, Int>(1, 2, 3)
 
         subject.append(4, 5, 6)
 
-        expect(subject.call()).to(equal(1))
-        expect(subject.call()).to(equal(2))
-        expect(subject.call()).to(equal(3))
-        expect(subject.call()).to(equal(4))
-        expect(subject.call()).to(equal(5))
-        expect(subject.call()).to(equal(6))
+        #expect(subject.call() == 1)
+        #expect(subject.call() == 2)
+        #expect(subject.call() == 3)
+        #expect(subject.call() == 4)
+        #expect(subject.call() == 5)
+        #expect(subject.call() == 6)
         // After the last call, we continue to return the last stub in the list
-        expect(subject.call()).to(equal(6))
+        #expect(subject.call() == 6)
     }
 
-    func testAppendingClosure() {
+    @Test func testAppendingClosure() {
         let subject = DynamicResult<Int, Int>(1, 2, 3)
 
         subject.append({ $0 + 10})
 
-        expect(subject.call(1)).to(equal(1))
-        expect(subject.call(2)).to(equal(2))
-        expect(subject.call(3)).to(equal(3))
-        expect(subject.call(4)).to(equal(14))
-        expect(subject.call(5)).to(equal(15))
+        #expect(subject.call(1) == 1)
+        #expect(subject.call(2) == 2)
+        #expect(subject.call(3) == 3)
+        #expect(subject.call(4) == 14)
+        #expect(subject.call(5) == 15)
     }
 
-    func testAppendingStubs() {
+    @Test func testAppendingStubs() {
         let subject = DynamicResult<Int, Int>(1, 2, 3)
 
         subject.append(
@@ -121,12 +120,12 @@ final class DynamicResultTests: XCTestCase {
             .value(6)
         )
 
-        expect(subject.call(1)).to(equal(1))
-        expect(subject.call(2)).to(equal(2))
-        expect(subject.call(3)).to(equal(3))
-        expect(subject.call(4)).to(equal(4))
-        expect(subject.call(5)).to(equal(15))
-        expect(subject.call(6)).to(equal(6))
-        expect(subject.call(7)).to(equal(6))
+        #expect(subject.call(1) == 1)
+        #expect(subject.call(2) == 2)
+        #expect(subject.call(3) == 3)
+        #expect(subject.call(4) == 4)
+        #expect(subject.call(5) == 15)
+        #expect(subject.call(6) == 6)
+        #expect(subject.call(7) == 6)
     }
 }

--- a/Tests/FakesTests/PropertySpyTests.swift
+++ b/Tests/FakesTests/PropertySpyTests.swift
@@ -1,9 +1,8 @@
 import Fakes
-import Nimble
-import XCTest
+import Testing
 
-final class SettablePropertySpyTests: XCTestCase {
-    func testGettingPropertyWhenTypesMatch() {
+struct SettablePropertySpyTests {
+    @Test func testGettingPropertyWhenTypesMatch() {
         struct AnObject {
             @SettablePropertySpy(1)
             var value: Int
@@ -11,15 +10,15 @@ final class SettablePropertySpyTests: XCTestCase {
 
         let object = AnObject()
 
-        expect(object.value).to(equal(1))
+        #expect(object.value == 1)
         // because we called it, we should expect for the getter spy to be called
-        expect(object.$value.getter).to(beCalled())
+        #expect(object.$value.getter.wasCalled)
 
         // We never interacted with the setter, so it shouldn't have been called.
-        expect(object.$value.setter).toNot(beCalled())
+        #expect(object.$value.setter.wasNotCalled)
     }
 
-    func testSettingPropertyWhenTypesMatch() {
+    @Test func testSettingPropertyWhenTypesMatch() {
         struct AnObject {
             @SettablePropertySpy(1)
             var value: Int
@@ -28,17 +27,17 @@ final class SettablePropertySpyTests: XCTestCase {
         var object = AnObject()
         object.value = 3
 
-        expect(object.$value.getter).toNot(beCalled())
-        expect(object.$value.setter).to(beCalled(3))
+        #expect(object.$value.getter.wasNotCalled)
+        #expect(object.$value.setter.wasCalled(with: 3))
 
         // the returned value should now be updated with the new value
-        expect(object.value).to(equal(3))
+        #expect(object.value == 3)
 
         // and because we called the getter, the getter spy should be called.
-        expect(object.$value.getter).to(beCalled())
+        #expect(object.$value.getter.wasCalled)
     }
 
-    func testGettingPropertyProtocolInheritence() {
+    @Test func testGettingPropertyProtocolInheritence() {
         struct ImplementedProtocol: SomeProtocol {
             var value: Int = 1
         }
@@ -50,15 +49,15 @@ final class SettablePropertySpyTests: XCTestCase {
 
         let object = AnObject()
 
-        expect(object.value).to(beAKindOf(ImplementedProtocol.self))
+        #expect(object.value is ImplementedProtocol)
         // because we called it, we should expect for the getter spy to be called
-        expect(object.$value.getter).to(beCalled())
+        #expect(object.$value.getter.wasCalled)
 
         // We never interacted with the setter, so it shouldn't have been called.
-        expect(object.$value.setter).toNot(beCalled())
+        #expect(object.$value.setter.wasNotCalled)
     }
 
-    func testSettingPropertyProtocolInheritence() {
+    @Test func testSettingPropertyProtocolInheritence() {
         struct ImplementedProtocol: SomeProtocol, Equatable {
             var value: Int = 1
         }
@@ -71,24 +70,17 @@ final class SettablePropertySpyTests: XCTestCase {
         var object = AnObject()
         object.value = ImplementedProtocol(value: 2)
 
-        expect(object.$value.getter).toNot(beCalled())
-        expect(object.$value.setter).to(beCalled(satisfyAllOf(
-            beAKindOf(ImplementedProtocol.self),
-            map(\.value, equal(2))
-        )))
+        #expect(object.$value.getter.wasNotCalled)
 
         // the returned value should now be updated with the new value
-        expect(object.value).to(satisfyAllOf(
-            beAKindOf(ImplementedProtocol.self),
-            map(\.value, equal(2))
-        ))
+        #expect((object.value as? ImplementedProtocol)?.value == 2)
         // and because we called the getter, the getter spy should be called.
-        expect(object.$value.getter).to(beCalled(times: 1))
+        #expect(object.$value.getter.wasCalled(times: 1))
     }
 }
 
-final class PropertySpyTests: XCTestCase {
-    func testGettingPropertyWhenTypesMatch() {
+struct PropertySpyTests {
+    @Test func testGettingPropertyWhenTypesMatch() {
         struct AnObject {
             @PropertySpy(1)
             var value: Int
@@ -96,12 +88,12 @@ final class PropertySpyTests: XCTestCase {
 
         let object = AnObject()
 
-        expect(object.value).to(equal(1))
+        #expect(object.value == 1)
         // because we called it, we should expect for the getter spy to be called
-        expect(object.$value).to(beCalled())
+        #expect(object.$value.wasCalled)
     }
 
-    func testGettingPropertyProtocolInheritence() {
+    @Test func testGettingPropertyProtocolInheritence() {
         struct ImplementedProtocol: SomeProtocol {
             var value: Int = 1
         }
@@ -118,14 +110,12 @@ final class PropertySpyTests: XCTestCase {
 
         let object = ObjectUsingProtocol()
 
-        expect(object.value).to(beAnInstanceOf(ImplementedProtocol.self))
+        #expect(object.value is ImplementedProtocol)
         // because we called it, we should expect for the getter spy to be called
-        expect(object.$value).to(beCalled())
-        expect(object.$value).to(beAnInstanceOf(Spy<Void, SomeProtocol>.self))
+        #expect(object.$value.wasCalled)
 
-        let otherObject = ObjectUsingDirectInstance()
-
-        expect(otherObject.$value).to(beAnInstanceOf(Spy<Void, ImplementedProtocol>.self))
+        // it can be initialized and expressed.
+        let _ = ObjectUsingDirectInstance()
     }
 }
 

--- a/Tests/FakesTests/SpyTests+Nimble.swift
+++ b/Tests/FakesTests/SpyTests+Nimble.swift
@@ -1,9 +1,10 @@
+#if Include_Nimble
 import Nimble
-import XCTest
+import Testing
 import Fakes
 
-final class SpyNimbleMatchersTest: XCTestCase {
-    func testBeCalledWithoutArguments() {
+struct SpyNimbleMatchersTest {
+    @Test func testBeCalledWithoutArguments() {
         let spy = Spy<Int, Void>()
 
         // beCalled should match if spy has been called any number of times.
@@ -16,7 +17,7 @@ final class SpyNimbleMatchersTest: XCTestCase {
         expect(spy).to(beCalled())
     }
 
-    func testBeCalledWithArguments() {
+    @Test func testBeCalledWithArguments() {
         let spy = Spy<Int, Void>()
 
         expect(spy).toNot(beCalled())
@@ -30,7 +31,7 @@ final class SpyNimbleMatchersTest: XCTestCase {
         expect(spy).to(beCalled(3))
     }
 
-    func testBeCalledWithMultipleArguments() {
+    @Test func testBeCalledWithMultipleArguments() {
         let spy = Spy<Int, Void>()
 
         spy(3)
@@ -44,7 +45,7 @@ final class SpyNimbleMatchersTest: XCTestCase {
         ))
     }
 
-    func testBeCalledWithTimes() {
+    @Test func testBeCalledWithTimes() {
         let spy = Spy<Int, Void>()
 
         expect(spy).to(beCalled(times: 0))
@@ -62,7 +63,7 @@ final class SpyNimbleMatchersTest: XCTestCase {
         expect(spy).toNot(beCalled(times: 1))
     }
 
-    func testBeCalledWithArgumentsAndTimes() {
+    @Test func testBeCalledWithArgumentsAndTimes() {
         let spy = Spy<Int, Void>()
 
         spy(1)
@@ -80,7 +81,7 @@ final class SpyNimbleMatchersTest: XCTestCase {
         expect(spy).to(beCalled(3, times: 2))
     }
 
-    func testBeCalledWithMultipleArgumentsAndTimes() {
+    @Test func testBeCalledWithMultipleArgumentsAndTimes() {
         let spy = Spy<Int, Void>()
 
         spy(1)
@@ -93,7 +94,7 @@ final class SpyNimbleMatchersTest: XCTestCase {
         expect(spy).to(beCalled(equal(3), beLessThan(4), times: 2))
     }
 
-    func testMostRecentlyBeCalled() {
+    @Test func testMostRecentlyBeCalled() {
         let spy = Spy<Int, Void>()
 
         spy(1)
@@ -110,7 +111,7 @@ final class SpyNimbleMatchersTest: XCTestCase {
         expect(spy).to(mostRecentlyBeCalled(2))
     }
 
-    func testMostRecentlyBeCalledWithMultipleArguments() {
+    @Test func testMostRecentlyBeCalledWithMultipleArguments() {
         let spy = Spy<Int, Void>()
 
         spy(1)
@@ -134,3 +135,4 @@ final class SpyNimbleMatchersTest: XCTestCase {
         ))
     }
 }
+#endif


### PR DESCRIPTION
Breaking change, wait until v2 to merge.

This makes the Nimble integration a package trait. Useful for those who want to use this library without also having to depend on Nimble.

It also reimplements the tests to use Swift Testing - because I already had to make changes to drop Nimble usage in the tests. This will improve test performance, not that these were slow in the first place.