### PR TITLE
Add package traits for Nimble dependency

### DIFF
--- a/.github/workflows/ci-swiftpm.yml
+++ b/.github/workflows/ci-swiftpm.yml
@@ -66,6 +66,7 @@ jobs:
           - swift:6.0
           - swift:6.1
           - swift:6.2
+          - swift:6.3
       fail-fast: false
     container: ${{ matrix.container }}
     steps:

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -13,10 +13,6 @@ let package = Package(
             targets: ["Fakes"]
         ),
     ],
-    traits: [
-        "Nimble",
-        .default(enabledTraits: ["Nimble"]),
-    ],
     dependencies: [
         .package(url: "https://github.com/Quick/Nimble.git", from: "14.0.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
@@ -24,20 +20,20 @@ let package = Package(
     targets: [
         .target(
             name: "Fakes",
-            dependencies: [
-                .product(
-                    name: "Nimble",
-                    package: "Nimble",
-                    condition: .when(traits: ["Nimble"])
-                ),
-            ],
+            dependencies: ["Nimble"],
             resources: [
                 .copy("PrivacyInfo.xcprivacy")
+            ],
+            swiftSettings: [
+                .define("Nimble"),
             ]
         ),
         .testTarget(
             name: "FakesTests",
-            dependencies: ["Fakes", "Nimble"]
+            dependencies: ["Fakes", "Nimble"],
+            swiftSettings: [
+                .define("Nimble"),
+            ]
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Include `"Fakes"` as a dependency for your test target:
 ]),
 ```
 
+### Nimble integration
+
+By default, `Fakes` depends on [Nimble](https://github.com/Quick/Nimble) and provides its extensions. If you don't use Nimble, you can opt out by disabling the `Nimble` trait:
+
+```swift
+.package(url: "https://github.com/Quick/swift-fakes", from: "0.1.1", traits: []),
+```
+
 ## Motivation
 
 When writing tests, we want to write one thing at a time. This is best done by

--- a/Sources/Fakes/Spy/Spy+Nimble.swift
+++ b/Sources/Fakes/Spy/Spy+Nimble.swift
@@ -1,3 +1,4 @@
+#if Nimble
 import Nimble
 
 // MARK: - Verifying any calls to the Spy.
@@ -303,3 +304,4 @@ private func _mostRecentlyBeCalled<Arguments, Returning>(
         )
     }
 }
+#endif


### PR DESCRIPTION
This PR adopts Swift Package Manager traits to make the Nimble dependency opt-out.
Since not all users of swift-fakes use Nimble, this change allows users who don't need it to exclude the Nimble dependency.           

By default, Fakes depends on Nimble and provides the `beCalled` and `mostRecentlyBeCalled` matchers.
To opt out, disable the Nimble trait:

```swift
.package(url: "https://github.com/Quick/swift-fakes", from: "0.1.1", traits: []),                                                     
```

A Package@swift-6.0.swift fallback is included for Swift 6.0–6.2 toolchains, where Nimble remains always included.

## Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [x] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [x] Is this a new feature (Requires minor version bump)?
