### PR TITLE
Fix flaky testDynamicPendable

### DIFF
--- a/Tests/FakesTests/SpyTests.swift
+++ b/Tests/FakesTests/SpyTests.swift
@@ -194,7 +194,9 @@ final class SpyTests: XCTestCase {
             await subject()
         }
 
-        await expect { await managedTask.isFinished }.toNever(beTrue())
+        await expect { await managedTask.hasStarted }.toEventually(beTrue())
+        await expect { subject.calls }.toEventually(haveCount(1))
+        await expect { await managedTask.isFinished }.to(beFalse())
 
         subject.resolveStub(with: ())
 


### PR DESCRIPTION
##  Problem

A unit test `testDynamicPendable` fails on Darwin CI (swiftpm_darwin,  swiftpm_darwin_15) while Linux environments continue to pass.

##  Root Cause

#30 bumps Nimble to 14.0.0 which changed the `pollBlock` implementation at https://github.com/Quick/Nimble/commit/5a0cc379658a8f233c907c50b7f2e66875fc4464 .
`pollBlock` now iterates a fixed number of times instead of checking wall-clock time.

The number of iterations is calculated at https://github.com/Quick/Nimble/blob/727f75d91a0f7501d08d938966d17e6728b76a2a/Sources/Nimble/Utils/PollAwait.swift#L196 which evaluates to 100 in this case.

On Darwin CI, each `await managedTask.isFinished` evaluation requires an actor hop which takes additional time (~10ms). This makes the total polling duration approach PendableDefaults.delay (2 seconds):
  100 × 10ms (eval) + 99 × 10ms (sleep) ≈ 2s
  
As a result, the `Pendable` 's fallback resolves during the `toNever` window, making `isFinished` become `true` and failing the assertion. On Linux, actor hops are fast enough that the total duration stays well below 2 seconds.
  
##  Fix

Replace `toNever` with deterministic assertions that don't rely on timing. Once `subject.calls` has one entry, the task is definitively suspended waiting for the `Pendable` — `isFinished` must be `false` at that point.

```swift
// Before
await expect { await managedTask.isFinished }.toNever(beTrue())

// After
await expect { await managedTask.hasStarted }.toEventually(beTrue())
await expect { subject.calls }.toEventually(haveCount(1))
await expect { await managedTask.isFinished }.to(beFalse())
```

## Checklist - While not every PR needs it, new features should consider this list:

 - [x] Does this have tests?
 - [ ] Does this have documentation?
 - [ ] Does this break the public API (Requires major version bump)?
 - [ ] Is this a new feature (Requires minor version bump)?
